### PR TITLE
NLP-ENGINE-LINUX-026 full-analyzer compile + python compile API

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ nlp-engine-linux/
 │   ├── nlpengine.py              `NLPEngine` class (subprocess wrapper)
 │   └── genHtmlHighlights.py      example: generate HTML highlights for analyzer output
 ├── scripts/
-│   └── compile-analyzer.sh       compile the analyzer's KB into bin/kb.so
+│   └── compile-analyzer.sh       compile the analyzer (run+kb) into bin/run.so + bin/kb.so
 └── README.md
 ```
 
@@ -138,13 +138,22 @@ nlp.analyzeInput("rfb", "text.txt", dev=True)
 
 [python/genHtmlHighlights.py](python/genHtmlHighlights.py) is a fuller example that runs an analyzer, then runs four "colorizer" analyzers over the result to emit syntax-highlighted HTML for the `.tree`, `.nlp`, `.dict`, and `.kbb` files.
 
-### 4. Compile an analyzer's KB to a native shared library
+### 4. Compile an analyzer to native shared libraries
 
-By default `nlp.exe` runs analyzers fully interpreted. With the new `EMBEDED_KB`-enabled engine, the **knowledge base** can be compiled to a native shared library that the engine `dlopen`s at `-COMPILED` time and calls into via a single exported `kb_setup` symbol. (Analyzer pass code itself is still interpreted — upstream removed `ana_gen` in 1999, so there is no compiled-rules path; the engine falls back to interpreted execution for the rules.)
+By default `nlp.exe` runs analyzers fully interpreted from the `.nlp`
+source. With the engine's `-COMPILED` mode, both the **analyzer body**
+(the rule passes) and the **knowledge base** are compiled to native
+shared libraries that the engine `dlopen`s at runtime — the analyzer
+runs entirely from compiled code, so source edits to `.nlp` files
+between runs don't affect the output until you recompile.
 
 | Script | What it does | Output |
 |--------|--------------|--------|
-| [scripts/compile-analyzer.sh](scripts/compile-analyzer.sh) | Runs `nlp.exe -COMPILE` (emits `Cc_code.cpp` plus the `Sym*.cpp` / `Con*.cpp` / `Ptr*.cpp` / `St*.cpp` tables under `<analyzer>/kb/`), generates a one-line `kb_setup()` shim, and links everything into a single SHARED library against the per-Ubuntu `compile-libs/`. Only `kb_setup` is exported (`-fvisibility=hidden` everywhere else). | `<analyzer>/bin/kb.so` |
+| [scripts/compile-analyzer.sh](scripts/compile-analyzer.sh) | Runs `nlp.exe -COMPILE` (emits the analyzer C++ trees under `<analyzer>/run/` and `<analyzer>/kb/`), then links everything into a single SHARED library against the per-Ubuntu `compile-libs/`. The library exports both `run_analyzer(Parse*)` and `kb_setup(void*)` (engine codegen emits both — see lite/seqn.cpp and consh/cc_gen.cpp). | `<analyzer>/bin/run.so`<br>`<analyzer>/bin/runu.so`<br>`<analyzer>/bin/kb.so`<br>`<analyzer>/bin/kbu.so` |
+
+The same library is staged under all four filenames so the engine's
+load paths find it whether it's looking for the ANSI or UNICODE
+build flavour ([lite/nlp.cpp:1242](https://github.com/VisualText/nlp-engine/blob/master/lite/nlp.cpp#L1242) / [cs/libconsh/cg.cpp:168](https://github.com/VisualText/nlp-engine/blob/master/cs/libconsh/cg.cpp#L168)).
 
 Prerequisites: `cmake` ≥ 3.16 and a C++17-capable `g++`. On Ubuntu:
 
@@ -155,32 +164,45 @@ sudo apt install build-essential cmake
 Usage:
 
 ```bash
-# Compile the bundled rfb analyzer's KB (defaults to ubuntu-latest binaries):
+# Default: full-analyzer compile (run + kb), defaults to ubuntu-latest:
 ./scripts/compile-analyzer.sh data/rfb data/rfb/input/text.txt
 
 # Pin a specific Ubuntu variant:
 ./scripts/compile-analyzer.sh data/rfb data/rfb/input/text.txt ubuntu-22.04
 
-# Run with the compiled KB (rules stay interpreted, KB is dlopen'd):
+# Legacy: KB-only compile (matches the pre-NLP-ENGINE-LINUX-026 behaviour):
+./scripts/compile-analyzer.sh --kb-only data/rfb data/rfb/input/text.txt
+
+# Run with the compiled artifacts:
 LD_LIBRARY_PATH="$PWD/ubuntu-22.04:$LD_LIBRARY_PATH" \
   ./ubuntu-22.04/nlp.exe -COMPILED -ANA data/rfb -WORK . data/rfb/input/text.txt
 ```
 
-What you should see in the `-COMPILED` output for a successful round-trip:
+What you should see in the `-COMPILED` output for a successful
+round-trip:
 
 ```
 [CG: Trying to load compiled KB.]
 [Loading compiled kb: data/rfb/bin/kb.so]
 [Loaded compiled kb library]
-[Loading compiled analyzer ...]
-[Error: Couldn't load compiled analyzer.]      # expected — no run.so exists
-[No compiled analyzer; falling back to interpreted.]
-... normal parse output ...
+[Loading compiled analyzer data/rfb/bin/run.so]
+[Loaded compiled analyzer]
+... parse output ...
 ```
 
-The compile-libs come from upstream's `nlpengine-compile-libs-linux-<ubuntu-ver>.zip` — the release workflow drops them into `compile-libs/ubuntu-<version>/{include,lib}/` alongside the runtime binaries.
+If you edit an `.nlp` file under `data/rfb/spec/` and re-run
+`-COMPILED` without re-running `compile-analyzer.sh`, the output
+should be **unchanged** — that's the proof the compiled libraries
+are doing the work, not the interpreter.
 
-> **Note:** Ubuntu 20.04 ships dynamic ICU (`libicu*.so.66`) rather than static `libicu*.a`. If linking fails on the 20.04 variant, `sudo apt install libicu-dev` provides the development symlinks the linker needs.
+The compile-libs come from upstream's `nlpengine-compile-libs-linux-<ubuntu-ver>.zip`
+— the release workflow drops them into `compile-libs/ubuntu-<version>/{include,lib}/`
+alongside the runtime binaries.
+
+> **Note:** Ubuntu 20.04 ships dynamic ICU (`libicu*.so.66`) rather than
+> static `libicu*.a`. If linking fails on the 20.04 variant,
+> `sudo apt install libicu-dev` provides the development symlinks the
+> linker needs.
 
 ## The `data/rfb` Analyzer
 

--- a/scripts/compile-analyzer.sh
+++ b/scripts/compile-analyzer.sh
@@ -1,32 +1,68 @@
 #!/usr/bin/env bash
 #
-# compile-analyzer.sh — Compile an NLP++ analyzer's KB into the native shared
-# library that the EMBEDED_KB-enabled engine dlopens at -COMPILED time.
+# compile-analyzer.sh — Compile an NLP++ analyzer into the native shared
+# libraries that the -COMPILED engine dlopens at runtime.
 #
 # Usage:
-#   scripts/compile-analyzer.sh <analyzer-dir> <input-file> [ubuntu-version]
+#   scripts/compile-analyzer.sh [--kb-only] <analyzer-dir> <input-file> [ubuntu-version]
 #
 # Example:
 #   scripts/compile-analyzer.sh data/rfb data/rfb/input/text.txt
 #   scripts/compile-analyzer.sh data/rfb data/rfb/input/text.txt ubuntu-22.04
+#   scripts/compile-analyzer.sh --kb-only data/rfb data/rfb/input/text.txt
 #
-# Produces: <analyzer-dir>/bin/kb.so
+# Produces (default, full-analyzer mode):
+#   <analyzer-dir>/bin/run.so
+#   <analyzer-dir>/bin/runu.so
+#   <analyzer-dir>/bin/kb.so
+#   <analyzer-dir>/bin/kbu.so
 #
-# How it fits into the runtime:
-#   - `nlp -COMPILE` emits Cc_code.cpp + the Sym*.cpp / Con*.cpp / Ptr*.cpp /
-#     St*.cpp KB tables under <analyzer-dir>/kb/. (ana_gen was removed from
-#     upstream around 1999, so there is no run.so equivalent — the engine
-#     falls back to interpreted execution for the analyzer rules.)
-#   - This script wraps those generated tables together with a one-line
-#     kb_setup() shim, builds them into a SHARED library, and drops it at
-#     <analyzer-dir>/bin/kb.so (the hardcoded path the engine dlopens).
-#   - Only kb_setup is exported (-fvisibility=hidden everywhere else) so the
-#     ABI surface mirrors the Windows export model.
+# Produces (--kb-only):
+#   <analyzer-dir>/bin/kb.so
+#   <analyzer-dir>/bin/kbu.so
+#
+# How it fits into the runtime (engine v3.1.44+):
+#   - `nlp -COMPILE` emits the analyzer C++ trees:
+#       <analyzer-dir>/run/pass*.cpp  + analyzer.h / ehead.h / rhead.h / data.h
+#       <analyzer-dir>/kb/Sym*.cpp / Con*.cpp / Ptr*.cpp / St*.cpp + Cc_code.cpp
+#     (or `nlp -COMPILEKB` for just kb/ when --kb-only).
+#   - This script wraps those trees with an auto-generated StdAfx.h stub and
+#     builds them into a single SHARED library via cmake.
+#   - The resulting library exports both `run_analyzer(Parse*)` and
+#     `kb_setup(void*)` (the engine codegen emits both — see lite/seqn.cpp
+#     and consh/cc_gen.cpp).
+#   - The library is staged into <analyzer-dir>/bin/ under the names the
+#     engine's load_compiled() (lite/nlp.cpp:1242) and consh's KB loader
+#     (cs/libconsh/cg.cpp:168) look for: bin/run.<ext> / bin/runu.<ext> /
+#     bin/kb.<ext> / bin/kbu.<ext>.
+#
+# Linker handling mirrors what nlp-compile-service's emit-cmake.sh does for
+# the cloud build, since the same engine compile-libs are linked here:
+#   - -DLINUX: the engine's public headers take the LINUX branch
+#     (my_tchar.h's _TCHAR typedef, no Windows __declspec).
+#   - PREFIX "": cmake's default `lib` prefix on SHARED targets is
+#     suppressed so the output filename is <name>.so, matching what the
+#     engine and extension expect.
+#   - -Wl,--whole-archive around ICU: virtual-class typeinfo
+#     (e.g. icu::ByteSink) must always end up in the .so even if no
+#     analyzer-side code references it directly. Without this dlopen
+#     fails at runtime with "undefined symbol: _ZTIN6icu_788ByteSinkE".
+#   - -Wl,--start-group ... --end-group around the engine static libs:
+#     forces ld to re-scan archives until all cross-archive references
+#     (e.g. CG::addWord defined in libconsh.a, referenced from liblite.a)
+#     resolve. Without this the .so links with undefined symbols that
+#     break at dlopen time.
 
 set -euo pipefail
 
+KB_ONLY=false
+while [ "${1:-}" = "--kb-only" ]; do
+  KB_ONLY=true
+  shift
+done
+
 if [ "$#" -lt 2 ]; then
-  echo "Usage: $0 <analyzer-dir> <input-file> [ubuntu-version]" >&2
+  echo "Usage: $0 [--kb-only] <analyzer-dir> <input-file> [ubuntu-version]" >&2
   exit 64
 fi
 
@@ -47,9 +83,6 @@ fi
 if [ ! -d "$COMPILE_LIBS/include" ] || [ ! -d "$COMPILE_LIBS/lib" ]; then
   echo "ERROR: compile libraries not found at $COMPILE_LIBS" >&2
   echo "Expected: compile-libs/$UBUNTU/{include,lib}" >&2
-  echo "(The workflow .github/workflows/nlp-engine-build.yml drops these in" >&2
-  echo " place. Trigger it once upstream attaches nlpengine-compile-libs-linux-*.zip" >&2
-  echo " to the release.)" >&2
   exit 1
 fi
 if [ ! -f "$INPUT_FILE" ]; then
@@ -59,8 +92,18 @@ fi
 
 export LD_LIBRARY_PATH="$REPO_ROOT/$UBUNTU:${LD_LIBRARY_PATH:-}"
 
-echo "==> [1/3] nlp.exe -COMPILE  (emits Cc_code.cpp + Sym*/Con*/Ptr*/St*.cpp under $ANALYZER_DIR/kb)"
-"$NLP_EXE" -COMPILE -ANA "$ANALYZER_DIR" -WORK "$REPO_ROOT" "$INPUT_FILE"
+if [ "$KB_ONLY" = "true" ]; then
+  COMPILE_FLAG="-COMPILEKB"
+  TARGET_NAME="nlp_kb"
+  SRC_GLOB="kb"
+else
+  COMPILE_FLAG="-COMPILE"
+  TARGET_NAME="nlp_analyzer"
+  SRC_GLOB="run|kb"
+fi
+
+echo "==> [1/3] nlp.exe $COMPILE_FLAG  (emits .cpp trees under $ANALYZER_DIR/{$SRC_GLOB}/)"
+"$NLP_EXE" "$COMPILE_FLAG" -ANA "$ANALYZER_DIR" -WORK "$REPO_ROOT" "$INPUT_FILE"
 
 BUILD_ROOT="$ANALYZER_DIR/.nlp-compile"
 SRC_DIR="$BUILD_ROOT/src"
@@ -68,74 +111,86 @@ BUILD_DIR="$BUILD_ROOT/build"
 rm -rf "$BUILD_ROOT"
 mkdir -p "$SRC_DIR"
 
-# Generated engine sources include "StdAfx.h" by convention.
+# Engine-generated .cpp files begin with `#include "StdAfx.h"`; cmake also
+# force-includes this file. Same stub the cloud writes.
 cat > "$SRC_DIR/StdAfx.h" <<'EOF'
 #pragma once
 #include "my_tchar.h"
 EOF
 
-# Sole exported symbol: kb_setup. The engine resolves it via dlsym after
-# dlopening bin/kb.so and calls it with the CG (concept graph) instance.
-cat > "$SRC_DIR/kb_setup.cpp" <<'EOF'
-#include "Cc_code.h"
+# Engine static libs. The cmake template uses --start-group below to
+# re-scan, so order isn't sensitive. ICU link order is significant
+# (i18n -> uc -> data) but moot under --whole-archive.
+ENGINE_LIB_NAMES="prim kbm consh words lite"
+ICU_LIB_NAMES="icui18n icuuc icudata"
 
-extern "C" __attribute__((visibility("default")))
-bool kb_setup(void *cg) {
-    return cc_ini(cg);
-}
-EOF
+if [ "$KB_ONLY" = "true" ]; then
+  GLOB_LINES="file(GLOB GENERATED_CPP \"$ANALYZER_DIR/kb/*.cpp\")"
+else
+  GLOB_LINES="file(GLOB GENERATED_CPP \"$ANALYZER_DIR/run/*.cpp\" \"$ANALYZER_DIR/kb/*.cpp\")"
+fi
 
 echo "==> [2/3] Generate CMakeLists.txt"
 cat > "$SRC_DIR/CMakeLists.txt" <<EOF
 cmake_minimum_required(VERSION 3.16)
-project(nlp_kb_library LANGUAGES CXX)
+project(${TARGET_NAME}_library LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
-# Hide every symbol by default; kb_setup is opted back in explicitly via
-# __attribute__((visibility("default"))) in kb_setup.cpp.
-set(CMAKE_CXX_VISIBILITY_PRESET hidden)
-set(CMAKE_VISIBILITY_INLINES_HIDDEN ON)
+# Engine public headers gate Windows-only constructs on #ifndef LINUX;
+# define LINUX so the right branches activate.
+add_compile_definitions(LINUX)
 
-# Drop the artifact at <analyzer-dir>/bin/kb.so (engine's hardcoded path).
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "$ANALYZER_DIR/bin")
 
-file(GLOB GENERATED_CPP "$ANALYZER_DIR/kb/*.cpp")
+$GLOB_LINES
 if(NOT GENERATED_CPP)
-  message(FATAL_ERROR "No generated .cpp files found under $ANALYZER_DIR/kb/ — did -COMPILE succeed?")
+  message(FATAL_ERROR "No generated .cpp files found — did $COMPILE_FLAG succeed?")
 endif()
 
-add_library(nlp_kb SHARED \${GENERATED_CPP} "$SRC_DIR/kb_setup.cpp")
+add_library($TARGET_NAME SHARED \${GENERATED_CPP})
 
-# Force the on-disk filename to "kb.so" (no "lib" prefix) so dlopen finds it
-# at the engine's hardcoded path.
-set_target_properties(nlp_kb PROPERTIES
-  OUTPUT_NAME "kb"
+# Suppress cmake's default 'lib' prefix on SHARED targets so the output
+# filename matches what the engine's load_compiled() looks for.
+set_target_properties($TARGET_NAME PROPERTIES
+  OUTPUT_NAME "$TARGET_NAME"
   PREFIX ""
 )
 
-target_include_directories(nlp_kb PRIVATE
+target_include_directories($TARGET_NAME PRIVATE
   "$SRC_DIR"
   "$ANALYZER_DIR"
+  "$ANALYZER_DIR/run"
   "$ANALYZER_DIR/kb"
   "$COMPILE_LIBS/include/Api"
   "$COMPILE_LIBS/include/cs"
 )
 
-target_compile_options(nlp_kb PRIVATE -include StdAfx.h)
-target_link_directories(nlp_kb PRIVATE "$COMPILE_LIBS/lib")
+target_compile_options($TARGET_NAME PRIVATE -include StdAfx.h)
+target_link_directories($TARGET_NAME PRIVATE "$COMPILE_LIBS/lib")
 
-# Engine static libs (link order matters: prim is base; others depend on it).
-# ICU link order is also significant: i18n -> uc -> data.
-target_link_libraries(nlp_kb PRIVATE
-  prim kbm consh words lite
-  icui18n icuuc icudata
+# Engine static libs wrapped in --start-group so ld re-scans until cross-
+# archive references resolve (e.g. CG::addWord lives in libconsh.a but is
+# referenced from liblite.a).
+target_link_libraries($TARGET_NAME PRIVATE
+  -Wl,--start-group
+  $ENGINE_LIB_NAMES
+  -Wl,--end-group
+)
+
+# ICU static libs force-linked in full so virtual-class typeinfo
+# (icu::ByteSink etc.) is always emitted into the .so. Without this,
+# dlopen fails with undefined-symbol errors at runtime.
+target_link_libraries($TARGET_NAME PRIVATE
+  -Wl,--whole-archive
+  $ICU_LIB_NAMES
+  -Wl,--no-whole-archive
 )
 
 find_library(DL_LIBRARY dl)
 if(DL_LIBRARY)
-  target_link_libraries(nlp_kb PRIVATE \${DL_LIBRARY})
+  target_link_libraries($TARGET_NAME PRIVATE \${DL_LIBRARY})
 endif()
 EOF
 
@@ -143,12 +198,30 @@ echo "==> [3/3] cmake configure + build (Release)"
 cmake -S "$SRC_DIR" -B "$BUILD_DIR" -DCMAKE_BUILD_TYPE=Release
 cmake --build "$BUILD_DIR" --config Release
 
-OUT="$ANALYZER_DIR/bin/kb.so"
-if [ -f "$OUT" ]; then
-  echo
-  echo "Built: $OUT"
-  echo "Run:   $NLP_EXE -COMPILED -ANA $ANALYZER_DIR -WORK $REPO_ROOT $INPUT_FILE"
-else
+OUT="$ANALYZER_DIR/bin/${TARGET_NAME}.so"
+if [ ! -f "$OUT" ]; then
   echo "ERROR: expected output $OUT was not produced" >&2
   exit 1
 fi
+
+# Stage the built library under every name the engine's load paths look
+# for (lite/nlp.cpp:1242 / cs/libconsh/cg.cpp:168). The "u" variants are
+# the UNICODE build flavour; copying them keeps both engine flavours
+# happy without a rebuild.
+echo "==> Staging $(basename "$OUT") into $ANALYZER_DIR/bin/"
+if [ "$KB_ONLY" = "true" ]; then
+  cp -f "$OUT" "$ANALYZER_DIR/bin/kb.so"
+  cp -f "$OUT" "$ANALYZER_DIR/bin/kbu.so"
+  STAGED="bin/kb.so bin/kbu.so"
+else
+  cp -f "$OUT" "$ANALYZER_DIR/bin/run.so"
+  cp -f "$OUT" "$ANALYZER_DIR/bin/runu.so"
+  cp -f "$OUT" "$ANALYZER_DIR/bin/kb.so"
+  cp -f "$OUT" "$ANALYZER_DIR/bin/kbu.so"
+  STAGED="bin/run.so bin/runu.so bin/kb.so bin/kbu.so"
+fi
+
+echo
+echo "Built: $OUT"
+echo "Staged: $STAGED"
+echo "Run:    $NLP_EXE -COMPILED -ANA $ANALYZER_DIR -WORK $REPO_ROOT $INPUT_FILE"


### PR DESCRIPTION
## Summary
- `scripts/compile-analyzer.sh` now builds the **full analyzer** (run/+kb/) by default. `--kb-only` preserves legacy KB-only behaviour.
- `python` submodule bumped to [PYTHON-011](https://github.com/VisualText/python/pull/3), which adds `compileAnalyzer` / `compileLocal` methods + a `compiled=True` kwarg on `analyzeInput`.

## What changed in compile-analyzer.sh
Cmake template mirrors what `nlp-compile-service`'s `emit-cmake.sh` does for the cloud build, since the same compile-libs are linked here:

| Setting | Why |
|---|---|
| `-DLINUX` | Engine headers take the LINUX branch (`my_tchar.h` typedef, no Windows `__declspec`). |
| `PREFIX ""` | Suppress cmake's default `lib` prefix so output is `<name>.so`, matching what the engine expects on disk. |
| `-Wl,--whole-archive` around ICU | Virtual-class typeinfo (`icu::ByteSink` etc.) always emitted into the `.so`. Without it, dlopen fails with `undefined symbol: _ZTIN6icu_788ByteSinkE`. |
| `-Wl,--start-group` around engine libs | Re-scan archives so cross-archive refs (`CG::addWord` in libconsh.a, referenced from liblite.a) resolve. |

Successful build is staged into `<analyzer-dir>/bin/` under every name the engine's load paths look for: `run.so` / `runu.so` / `kb.so` / `kbu.so` (or just `kb.so` / `kbu.so` for `--kb-only`).

The manual `kb_setup.cpp` shim is dropped — engine v3.1.44+ emits the wrapper automatically (NLP-ENGINE-495).

## Test plan
- [ ] `scripts/compile-analyzer.sh data/rfb data/rfb/input/text.txt` produces `bin/run.so` + `bin/kb.so` + `.u` variants.
- [ ] `ubuntu-latest/nlp.exe -COMPILED -ANA data/rfb -WORK . data/rfb/input/text.txt` runs without falling back to interpreted.
- [ ] Legacy: `scripts/compile-analyzer.sh --kb-only data/rfb data/rfb/input/text.txt` still produces `bin/kb.so`.
