### PR TITLE
Fix auto-update workflow: git rm before extract, not after

### DIFF
--- a/.github/workflows/nlp-engine-build.yml
+++ b/.github/workflows/nlp-engine-build.yml
@@ -150,6 +150,38 @@ jobs:
         done
       shell: bash
 
+    # Force remove individual binary files using git rm. Must run BEFORE
+    # the extraction step below, otherwise `git rm -rf compile-libs` /
+    # `git rm -rf ubuntu-*` will wipe the freshly-extracted directory
+    # trees from the working tree (git rm with -r removes BOTH the index
+    # and the on-disk files under the given path; the "untracked files
+    # survive git rm" assumption only holds for untracked files OUTSIDE
+    # the path being removed). This regression flip-flopped between
+    # losing compile-libs/ (v3.1.53) and losing ubuntu-*/ (v3.1.54)
+    # depending on which sub-dir cleanup raced first; mirroring the
+    # ordering nlp-engine-windows already uses fixes it deterministically.
+    - name: Force remove old binary files
+      if: steps.check_tag.outputs.update_needed == 'true'
+      run: |
+        # Configure git for commits
+        git config --global user.name 'github-actions[bot]'
+        git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+
+        # Force remove binary files - DO NOT REMOVE data directory!
+        echo "Removing old binary files using git rm to ensure they're properly tracked..."
+        git rm -f --ignore-unmatch *.a nlp.exe || true
+        git rm -rf --ignore-unmatch ubuntu-20.04 ubuntu-22.04 ubuntu-latest || true
+        git rm -rf --ignore-unmatch compile-libs || true
+        git rm -f .version-flag || true
+
+        # Commit the removal
+        git commit -m "Remove old binary files before update to ${{ steps.get_release.outputs.tag_name }}" || echo "Nothing to commit - files may not exist yet"
+        git push || echo "Nothing to push"
+
+        # Verify files were removed
+        echo "Current files after removal:"
+        ls -la
+
     - name: Process Ubuntu packages and extract files
       if: steps.check_tag.outputs.update_needed == 'true'
       run: |
@@ -240,29 +272,6 @@ jobs:
           echo "Files in data directory:"
           ls -la data
         fi
-
-    # Force remove individual binary files using git rm
-    - name: Force remove old binary files
-      if: steps.check_tag.outputs.update_needed == 'true'
-      run: |
-        # Configure git for commits
-        git config --global user.name 'github-actions[bot]'
-        git config --global user.email 'github-actions[bot]@users.noreply.github.com'
-        
-        # Force remove binary files - DO NOT REMOVE data directory!
-        echo "Removing old binary files using git rm to ensure they're properly tracked..."
-        git rm -f --ignore-unmatch *.a nlp.exe || true
-        git rm -rf --ignore-unmatch ubuntu-20.04 ubuntu-22.04 ubuntu-latest || true
-        git rm -rf --ignore-unmatch compile-libs || true
-        git rm -f .version-flag || true
-        
-        # Commit the removal
-        git commit -m "Remove old binary files before update to ${{ steps.get_release.outputs.tag_name }}" || echo "Nothing to commit - files may not exist yet"
-        git push || echo "Nothing to push"
-        
-        # Verify files were removed
-        echo "Current files after removal:"
-        ls -la
 
     - name: Configure Git
       if: steps.check_tag.outputs.update_needed == 'true'


### PR DESCRIPTION
The auto-update workflow has been flip-flopping between losing `compile-libs/` (v3.1.53) and losing `ubuntu-*/` (v3.1.54). Root cause: the "Force remove old binary files" step runs `git rm -rf compile-libs` and `git rm -rf ubuntu-20.04 ubuntu-22.04 ubuntu-latest` AFTER the "Process Ubuntu packages and extract files" step has already extracted the freshly-downloaded tree onto disk. `git rm -rf <dir>` removes both the index entries AND the on-disk files under that path — including the just-extracted untracked files. The subsequent `git add -A` then has nothing to add for whichever dir lost the race, and the auto-update commit ends up missing it.

## Fix

Reorder so "Force remove old binary files" runs FIRST (operates on the previously-tracked old version's files only), then "Process Ubuntu packages and extract files" populates fresh, untracked content that survives unmolested into `git add -A`.

This mirrors the ordering [`nlp-engine-windows`](https://github.com/VisualText/nlp-engine-windows/blob/main/.github/workflows/nlp-engine-build.yml) has had for a while, which is documented in that repo's workflow with the same warning comment. Companion PR opened against [`nlp-engine-mac`](https://github.com/VisualText/nlp-engine-mac) in parallel.

## Confirmed against recent runs

- v3.1.52 commit 2979584: both dirs committed (worked, presumably by luck — the bug is timing-sensitive).
- v3.1.53 commit a351932: `ubuntu-*` committed, `compile-libs` lost.
- v3.1.54 commit (HEAD of main): `compile-libs` committed, `ubuntu-*` lost.

## Verification

After merge, the next `nlp-engine` release that fires the `repository_dispatch nlp-engine-release` event should populate both directory trees together deterministically. Worth a manual `workflow_dispatch` run after merging this to confirm before the next engine release.
