### PR TITLE
feat: add --analyzer-only compile mode (-COMPILEANA)

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,9 +147,13 @@ shared libraries that the engine `dlopen`s at runtime — the analyzer
 runs entirely from compiled code, so source edits to `.nlp` files
 between runs don't affect the output until you recompile.
 
-| Script | What it does | Output |
-|--------|--------------|--------|
-| [scripts/compile-analyzer.sh](scripts/compile-analyzer.sh) | Runs `nlp.exe -COMPILE` (emits the analyzer C++ trees under `<analyzer>/run/` and `<analyzer>/kb/`), then links everything into a single SHARED library against the per-Ubuntu `compile-libs/`. The library exports both `run_analyzer(Parse*)` and `kb_setup(void*)` (engine codegen emits both — see lite/seqn.cpp and consh/cc_gen.cpp). | `<analyzer>/bin/run.so`<br>`<analyzer>/bin/runu.so`<br>`<analyzer>/bin/kb.so`<br>`<analyzer>/bin/kbu.so` |
+| Mode | Flag | What it does | Output |
+|------|------|--------------|--------|
+| Full (default) | `-COMPILE` | Runs `nlp.exe -COMPILE` (emits the analyzer C++ trees under `<analyzer>/run/` and `<analyzer>/kb/`), then links everything into a single SHARED library against the per-Ubuntu `compile-libs/`. The library exports both `run_analyzer(Parse*)` and `kb_setup(void*)` (engine codegen emits both — see lite/seqn.cpp and consh/cc_gen.cpp). | `<analyzer>/bin/run.so`<br>`<analyzer>/bin/runu.so`<br>`<analyzer>/bin/kb.so`<br>`<analyzer>/bin/kbu.so` |
+| KB only | `--kb-only` (`-COMPILEKB`) | Compiles only the knowledge base. Use when only the KB changed. | `<analyzer>/bin/kb.so`<br>`<analyzer>/bin/kbu.so` |
+| Analyzer only | `--analyzer-only` (`-COMPILEANA`) | Compiles only the analyzer rules, leaving any existing `kb.so` in place. Use when only the rules changed and the KB is already compiled. | `<analyzer>/bin/run.so`<br>`<analyzer>/bin/runu.so` |
+
+[scripts/compile-analyzer.sh](scripts/compile-analyzer.sh) drives all three modes.
 
 The same library is staged under all four filenames so the engine's
 load paths find it whether it's looking for the ANSI or UNICODE
@@ -170,8 +174,12 @@ Usage:
 # Pin a specific Ubuntu variant:
 ./scripts/compile-analyzer.sh data/rfb data/rfb/input/text.txt ubuntu-22.04
 
-# Legacy: KB-only compile (matches the pre-NLP-ENGINE-LINUX-026 behaviour):
+# KB-only compile (-COMPILEKB): rebuild just kb.so / kbu.so:
 ./scripts/compile-analyzer.sh --kb-only data/rfb data/rfb/input/text.txt
+
+# Analyzer-only compile (-COMPILEANA): rebuild just run.so / runu.so,
+# leaving the existing kb.so in place. Use when only the rules changed:
+./scripts/compile-analyzer.sh --analyzer-only data/rfb data/rfb/input/text.txt
 
 # Run with the compiled artifacts:
 LD_LIBRARY_PATH="$PWD/ubuntu-22.04:$LD_LIBRARY_PATH" \

--- a/scripts/compile-analyzer.sh
+++ b/scripts/compile-analyzer.sh
@@ -55,14 +55,17 @@
 
 set -euo pipefail
 
-KB_ONLY=false
-while [ "${1:-}" = "--kb-only" ]; do
-  KB_ONLY=true
+MODE="full"
+while [ "${1:-}" = "--kb-only" ] || [ "${1:-}" = "--analyzer-only" ]; do
+  case "$1" in
+    --kb-only)       MODE="kb" ;;
+    --analyzer-only) MODE="ana" ;;
+  esac
   shift
 done
 
 if [ "$#" -lt 2 ]; then
-  echo "Usage: $0 [--kb-only] <analyzer-dir> <input-file> [ubuntu-version]" >&2
+  echo "Usage: $0 [--kb-only|--analyzer-only] <analyzer-dir> <input-file> [ubuntu-version]" >&2
   exit 64
 fi
 
@@ -92,15 +95,23 @@ fi
 
 export LD_LIBRARY_PATH="$REPO_ROOT/$UBUNTU:${LD_LIBRARY_PATH:-}"
 
-if [ "$KB_ONLY" = "true" ]; then
-  COMPILE_FLAG="-COMPILEKB"
-  TARGET_NAME="nlp_kb"
-  SRC_GLOB="kb"
-else
-  COMPILE_FLAG="-COMPILE"
-  TARGET_NAME="nlp_analyzer"
-  SRC_GLOB="run|kb"
-fi
+case "$MODE" in
+  kb)
+    COMPILE_FLAG="-COMPILEKB"
+    TARGET_NAME="nlp_kb"
+    SRC_GLOB="kb"
+    ;;
+  ana)
+    COMPILE_FLAG="-COMPILEANA"
+    TARGET_NAME="nlp_run"
+    SRC_GLOB="run"
+    ;;
+  *)
+    COMPILE_FLAG="-COMPILE"
+    TARGET_NAME="nlp_analyzer"
+    SRC_GLOB="run|kb"
+    ;;
+esac
 
 echo "==> [1/3] nlp.exe $COMPILE_FLAG  (emits .cpp trees under $ANALYZER_DIR/{$SRC_GLOB}/)"
 "$NLP_EXE" "$COMPILE_FLAG" -ANA "$ANALYZER_DIR" -WORK "$REPO_ROOT" "$INPUT_FILE"
@@ -124,11 +135,11 @@ EOF
 ENGINE_LIB_NAMES="prim kbm consh words lite"
 ICU_LIB_NAMES="icui18n icuuc icudata"
 
-if [ "$KB_ONLY" = "true" ]; then
-  GLOB_LINES="file(GLOB GENERATED_CPP \"$ANALYZER_DIR/kb/*.cpp\")"
-else
-  GLOB_LINES="file(GLOB GENERATED_CPP \"$ANALYZER_DIR/run/*.cpp\" \"$ANALYZER_DIR/kb/*.cpp\")"
-fi
+case "$MODE" in
+  kb)  GLOB_LINES="file(GLOB GENERATED_CPP \"$ANALYZER_DIR/kb/*.cpp\")" ;;
+  ana) GLOB_LINES="file(GLOB GENERATED_CPP \"$ANALYZER_DIR/run/*.cpp\")" ;;
+  *)   GLOB_LINES="file(GLOB GENERATED_CPP \"$ANALYZER_DIR/run/*.cpp\" \"$ANALYZER_DIR/kb/*.cpp\")" ;;
+esac
 
 echo "==> [2/3] Generate CMakeLists.txt"
 cat > "$SRC_DIR/CMakeLists.txt" <<EOF
@@ -209,17 +220,25 @@ fi
 # the UNICODE build flavour; copying them keeps both engine flavours
 # happy without a rebuild.
 echo "==> Staging $(basename "$OUT") into $ANALYZER_DIR/bin/"
-if [ "$KB_ONLY" = "true" ]; then
-  cp -f "$OUT" "$ANALYZER_DIR/bin/kb.so"
-  cp -f "$OUT" "$ANALYZER_DIR/bin/kbu.so"
-  STAGED="bin/kb.so bin/kbu.so"
-else
-  cp -f "$OUT" "$ANALYZER_DIR/bin/run.so"
-  cp -f "$OUT" "$ANALYZER_DIR/bin/runu.so"
-  cp -f "$OUT" "$ANALYZER_DIR/bin/kb.so"
-  cp -f "$OUT" "$ANALYZER_DIR/bin/kbu.so"
-  STAGED="bin/run.so bin/runu.so bin/kb.so bin/kbu.so"
-fi
+case "$MODE" in
+  kb)
+    cp -f "$OUT" "$ANALYZER_DIR/bin/kb.so"
+    cp -f "$OUT" "$ANALYZER_DIR/bin/kbu.so"
+    STAGED="bin/kb.so bin/kbu.so"
+    ;;
+  ana)
+    cp -f "$OUT" "$ANALYZER_DIR/bin/run.so"
+    cp -f "$OUT" "$ANALYZER_DIR/bin/runu.so"
+    STAGED="bin/run.so bin/runu.so"
+    ;;
+  *)
+    cp -f "$OUT" "$ANALYZER_DIR/bin/run.so"
+    cp -f "$OUT" "$ANALYZER_DIR/bin/runu.so"
+    cp -f "$OUT" "$ANALYZER_DIR/bin/kb.so"
+    cp -f "$OUT" "$ANALYZER_DIR/bin/kbu.so"
+    STAGED="bin/run.so bin/runu.so bin/kb.so bin/kbu.so"
+    ;;
+esac
 
 echo
 echo "Built: $OUT"


### PR DESCRIPTION
Adds a third mode to `scripts/compile-analyzer.sh` matching nlp-engine 3.6.0's new **`-COMPILEANA`**:

| Mode | Flag | Output |
|------|------|--------|
| Full (default) | `-COMPILE` | run.so/runu.so + kb.so/kbu.so |
| KB only | `--kb-only` (`-COMPILEKB`) | kb.so/kbu.so |
| **Analyzer only** | `--analyzer-only` (`-COMPILEANA`) | run.so/runu.so |

`--analyzer-only` globs just `run/*.cpp` and stages `run.so`/`runu.so`, leaving any existing `kb.so` in place — for when only the rules changed and the KB is already compiled. README updated with all three modes.

Follow-up: bump the `python` submodule once VisualText/python#4 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)